### PR TITLE
Deprecated packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "PMCpy"
+version = "0.1.0"
+description = "ADD DESCRIPTION"
+authors = [
+    {name = "Enrico Skoruppa", email = "enrico.skoruppa@gmail.com"},
+]
+dependencies = [
+    "setuptools>=75.1.0",
+]
+requires-python = ">=3.9"
+readme = "README.md"
+license = {text = "GNU2"}
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[tool.pdm]
+distribution = true

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name="<REPO NAME>",
+    name="PMCpy",
     version="0.0.1",
     description="ADD DESCRIPTION",
     url="https://github.com/eskoruppa/<REPO NAME>",


### PR DESCRIPTION
Updated `setup.py` and added `pyproject.toml` to keep module installable with `pip>=25.0`. Fixes #3 